### PR TITLE
Vacancy api

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There are several functions implemented which do much of the work.
 * **user_get_day_periods**(id INTEGER, date_from TIMESTAMP, date_to TIMESTAMP): Return days between the interval for the user including the periods for that time
 * **user_get_start_date**(id integer): get first date for a user relevant for ttrack
 * **user_get_target_time**(id INTEGER, day_date DATE): get the calculated target time for a user on a given date.
+* **ttrack_get_all_vacations**(): get all vacations of all users from now to the beginning of ttrack
 
 ##### Helper Functions used by other Functions
 * **user_get_average_day_time**(id integer, day_date date): get the average day time of a user, does not check for workdays. (used by user_get_target_time)

--- a/migrations/20171006181803-vacationlist.js
+++ b/migrations/20171006181803-vacationlist.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20171006181803-vacationlist-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20171006181803-vacationlist-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20171006181803-vacationlist-down.sql
+++ b/migrations/sqls/20171006181803-vacationlist-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+DROP FUNCTION IF EXISTS ttrack_get_all_vacations();

--- a/migrations/sqls/20171006181803-vacationlist-up.sql
+++ b/migrations/sqls/20171006181803-vacationlist-up.sql
@@ -1,0 +1,34 @@
+/* introduce new function to get all vacations of all users */
+CREATE OR REPLACE FUNCTION ttrack_get_all_vacations ()
+  RETURNS TABLE(
+    day_id          INTEGER,
+    day_date        DATE,
+    day_usr_id      INTEGER,
+    day_target_time INTERVAL,
+    usr_firstname   TEXT,
+    usr_lastname    TEXT,
+    per_id          INTEGER,
+    per_comment     TEXT,
+    per_duration    INTERVAL
+  ) LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  RETURN QUERY SELECT
+                 days.day_id,
+                 days.day_date,
+                 days.day_usr_id,
+                 days.day_target_time,
+                 users.usr_firstname,
+                 users.usr_lastname,
+                 periods.per_id,
+                 periods.per_comment,
+                 periods.per_duration
+               FROM days
+                 JOIN periods on (days.day_id = periods.per_day_id)
+                 JOIN users on (days.day_usr_id = users.usr_id)
+               WHERE periods.per_pty_id = 'Vacation'
+                     AND days.day_date <= now()
+               ORDER BY days.day_date DESC, days.day_usr_id;
+END
+$$;
+COMMENT ON FUNCTION ttrack_get_all_vacations () IS 'get vacations for all users till today';

--- a/migrations/sqls/20171006181803-vacationlist-up.sql
+++ b/migrations/sqls/20171006181803-vacationlist-up.sql
@@ -3,8 +3,8 @@ CREATE OR REPLACE FUNCTION ttrack_get_all_vacations ()
   RETURNS TABLE(
     day_id          INTEGER,
     day_date        DATE,
-    day_usr_id      INTEGER,
     day_target_time INTERVAL,
+    usr_id          INTEGER,
     usr_firstname   TEXT,
     usr_lastname    TEXT,
     per_id          INTEGER,
@@ -16,8 +16,8 @@ BEGIN
   RETURN QUERY SELECT
                  days.day_id,
                  days.day_date,
-                 days.day_usr_id,
                  days.day_target_time,
+                 users.usr_id,
                  users.usr_firstname,
                  users.usr_lastname,
                  periods.per_id,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "migration": "db-migrate up",
     "migration-test": "db-migrate up --config database.json -e test",
-    "test": "NODE_ENV=test jest --bail --no-cache ./src/api/**/*",
+    "test": "NODE_ENV=test jest --bail --no-cache",
     "start": "npm-run-all --parallel lint start:server",
     "start:server": "nodemon  --harmony src/server.js",
     "lint": "eslint . --ext .js"

--- a/src/api/__test__/api-timesheet.test.js
+++ b/src/api/__test__/api-timesheet.test.js
@@ -43,6 +43,7 @@ describe('ttrack API', () => {
         });
 
         afterAll(async (done) => {
+            await query(`DELETE FROM days WHERE day_usr_id = ${user.usr_id}`);
             await query(`DELETE FROM user_target_times WHERE utt_usr_id = ${user.usr_id}`);
             await query(`DELETE FROM users WHERE usr_id = ${user.usr_id}`);
             done();

--- a/src/api/__test__/api-vacations.test.js
+++ b/src/api/__test__/api-vacations.test.js
@@ -1,0 +1,154 @@
+import Glue from 'glue';
+import path from 'path';
+import R from 'ramda';
+
+import { query } from '../../pg';
+import manifest from '../../config/manifest';
+
+const relativeTo = path.join(__dirname, '../../');
+const dummyUserSql = 'INSERT INTO users (usr_firstname , usr_lastname, usr_email) VALUES ( $1, $2, $3 ) RETURNING *';
+const daySql = 'INSERT INTO days (day_date, day_usr_id, day_target_time) VALUES ( $1, $2, $3) RETURNING *';
+const periodSql = 'INSERT INTO periods (per_day_id, per_duration, per_pty_id) VALUES ( $1, $2, $3) RETURNING *';
+const periodTypeVacation = 'Vacation';
+
+const apiVacationPath = '/api/vacations';
+
+describe('ttrack API', () => {
+    let Server;
+    beforeAll(async (done) => {
+        Glue.compose(manifest, { relativeTo }, (err, server) => {
+            if (err) {
+                console.log('server.register err:', err);
+            }
+            server.start(() => {
+                Server = server;
+                Server.log('✅  Server is listening on ' + server.info.uri.toLowerCase());
+                done();
+            });
+        });
+    });
+
+    afterAll(async (done) => {
+        await Server.stop();
+        done();
+    });
+
+    describe("Vacations /api/vacations", async () => {
+        let user;
+        let firstDay;
+        let secondDay;
+        let firstPeriod;
+        let secondPeriod;
+        beforeAll(async (done) => {
+            let result = await query(dummyUserSql, ['Mister', 'Smith', 'mister@smith.com']);
+            user = R.head(result.rows);
+            result = await query(daySql, ['2017-01-01', user.usr_id, '08:00:00']);
+            firstDay = R.head(result.rows);
+            result = await query(daySql, ['2017-01-02', user.usr_id, '08:00:00']);
+            secondDay = R.head(result.rows);
+            result = await query(periodSql, [firstDay.day_id, '08:00:00', periodTypeVacation]);
+            firstPeriod = R.head(result.rows);
+            result = await query(periodSql, [secondDay.day_id, '04:00:00', periodTypeVacation]);
+            secondPeriod = R.head(result.rows);
+            done();
+        });
+
+        afterAll(async (done) => {
+            await query('DELETE FROM days WHERE day_usr_id = $1', [user.usr_id]);
+            await query('DELETE FROM users WHERE usr_id = $1', [user.usr_id]);
+            done();
+        });
+
+        describe('testing GET requests', () => {
+
+            it('GET Api /api/vacations returns the vacations', async () => {
+                //let uri = Server.lookup('UserList').path;
+                const response = await Server.inject({ method: 'GET', url: apiVacationPath, });
+                expect(response.statusCode).toBe(200);
+                expect(response.result).toBeObject();
+                expect(response.result._meta).toEqual({
+                    "count": 2,
+                    "limit": 2,
+                    "start": 0,
+                    "total": 2,
+                });
+
+                let vacation_dates = R.map(
+                    R.prop('day_date')
+                )(response.result.vacations);
+
+                expect(vacation_dates).toEqual(expect.arrayContaining([
+                    secondDay.day_date,
+                    firstDay.day_date
+                ]));
+            });
+
+            it('GET Api /api/vacations returns full day vacations', async () => {
+                //let uri = Server.lookup('UserList').path;
+                const response = await Server.inject({ method: 'GET', url: apiVacationPath, });
+                expect(response.statusCode).toBe(200);
+
+                let vacations = R.filter(
+                    R.propEq('per_id',firstPeriod.per_id)
+                )(response.result.vacations);
+
+                expect(R.head(vacations)).toMatchObject({
+                    day_id: firstDay.day_id,
+                    day_date: firstDay.day_date,
+                    day_target_time: firstDay.day_target_time,
+                    usr_id: user.usr_id,
+                    usr_firstname: user.usr_firstname,
+                    usr_lastname: user.usr_lastname,
+                    per_id: firstPeriod.per_id,
+                    per_comment: firstPeriod.per_comment,
+                    per_duration:firstPeriod.per_duration,
+                });
+            });
+
+            it('GET Api /api/vacations returns half day vacations', async () => {
+                //let uri = Server.lookup('UserList').path;
+                const response = await Server.inject({ method: 'GET', url: apiVacationPath, });
+                expect(response.statusCode).toBe(200);
+
+                let vacations = R.filter(
+                    R.propEq('per_id',secondPeriod.per_id)
+                )(response.result.vacations);
+
+                expect(R.head(vacations)).toMatchObject({
+                    day_id: secondDay.day_id,
+                    day_date: secondDay.day_date,
+                    day_target_time: secondDay.day_target_time,
+                    usr_id: user.usr_id,
+                    usr_firstname: user.usr_firstname,
+                    usr_lastname: user.usr_lastname,
+                    per_id: secondPeriod.per_id,
+                    per_comment: secondPeriod.per_comment,
+                    per_duration:secondPeriod.per_duration,
+                });
+            });
+        });
+
+        describe('Test Method not implemented', ()=>{
+            it(`Should fail method is not implemented POST on /api/vacations`, async ()=>{
+                const response  = await Server.inject({ method: 'POST' , url: apiVacationPath });
+                expect(response.statusCode).toBe(405);
+            });
+
+            it('Should fail method is not implemented PUT on /api/vacations', async () => {
+                const PUT = await Server.inject({ method: 'PUT', url: apiVacationPath });
+                expect(PUT.statusCode).toBe(405);
+            });
+
+            it('Should fail method is not implemented DELETE on /api/vacations', async () => {
+                const DELETEmethod = await Server.inject({ method: 'DELETE', url: apiVacationPath });
+                expect(DELETEmethod.statusCode).toBe(405);
+            });
+
+            it('Should fail method is not implemented PATCH on /api/vacations', async () => {
+                const DELETEmethod = await Server.inject({ method: 'PATCH', url: apiVacationPath });
+                expect(DELETEmethod.statusCode).toBe(405);
+            });
+
+        });
+    });
+});

--- a/src/api/handlers/vacations.js
+++ b/src/api/handlers/vacations.js
@@ -64,17 +64,15 @@ module.exports.list = {
         let { start, limit } = request.query;
         if (start > total) start = total;
         if (limit > total) limit = total;
-        return list(start, limit)
-            .then(
-                success => reply({
-                    _meta: {
-                        total,
-                        limit,
-                        start,
-                        count: success.length,
-                    },
-                    vacations: success
-                }),
-            );
+        const success = await list(start, limit);
+        reply({
+            _meta: {
+                total,
+                limit,
+                start,
+                count: success.length,
+            },
+            vacations: success
+        });
     },
 };

--- a/src/api/handlers/vacations.js
+++ b/src/api/handlers/vacations.js
@@ -1,0 +1,80 @@
+const BaseJoi = require('joi');
+const Extension = require('joi-date-extensions');
+const R = require('ramda');
+const { query } = require('../../pg');
+
+const Joi = BaseJoi.extend(Extension);
+
+const {
+    Vacancy,
+} = require('../schema');
+
+const ListMeta = Joi.object({
+    "total": Joi.number().example('123'),
+    "limit": Joi.number().example('10'),
+    "start": Joi.number().example('0'),
+    "count": Joi.number().example('100'),
+});
+
+const listTotal = async () => {
+    const sql = 'SELECT count(*) as count FROM ttrack_get_all_vacations()';
+    const { rows } = await query(sql);
+    const count = (R.head(rows) || {}).count || 0;
+    return parseInt(count, 10);
+};
+
+const list = async (start, limit) => {
+    const sql = 'SELECT * FROM ttrack_get_all_vacations() LIMIT $1 OFFSET $2';
+    const { rows } = await query(sql, [limit, start]);
+    return rows;
+};
+
+module.exports.list = {
+    id: 'VacationList',
+    tags: ['api'],
+    description: 'fetches list of vacations',
+    notes:'Fetches a list of all vacations',
+    plugins: {
+        'hapi-swagger': {
+            responses: {
+                '200': {
+                    description: "list of vacations",
+                    schema: Joi.object({
+                        "_meta": ListMeta,
+                        "vacations": Joi.array().items(Vacancy).label('Vacations'),
+                    })
+                },
+                '400':{
+                    description: 'Bad Request',
+                },
+                '404':{
+                    description: 'Not Found',
+                }
+            },
+        },
+    },
+    validate: {
+        query: {
+            limit: Joi.number().integer().min(1).max(100).default(100),
+            start: Joi.number().integer().min(0).default(0),
+        }
+    },
+    handler: async function (request, reply) {
+        const total = await listTotal();
+        let { start, limit } = request.query;
+        if (start > total) start = total;
+        if (limit > total) limit = total;
+        return list(start, limit)
+            .then(
+                success => reply({
+                    _meta: {
+                        total,
+                        limit,
+                        start,
+                        count: success.length,
+                    },
+                    vacations: success
+                }),
+            );
+    },
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,7 +1,8 @@
-const User = require('./handlers/user')
-    , Period = require('./handlers/period')
-    , PeriodTypes = require('./handlers/periodTypes')
-    , Timesheet = require('./handlers/timesheet');
+const User = require('./handlers/user');
+const Period = require('./handlers/period');
+const PeriodTypes = require('./handlers/periodTypes');
+const Timesheet = require('./handlers/timesheet');
+const Vacations = require('./handlers/vacations');
 
 exports.register = (plugin, options, next) => {
     plugin.route([
@@ -20,6 +21,9 @@ exports.register = (plugin, options, next) => {
         // PeriodTypes
         { method: 'GET' , path: '/period-types', config: PeriodTypes.list },
         
+        // Vacations
+        { method: 'GET' , path: '/vacations', config: Vacations.list },
+
     ]);
     next();
 };

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -107,8 +107,8 @@ module.exports.PostPeriod = PostPeriod;
 const Vacancy = Joi.object({
     "day_id": Joi.number().example('123'),
     "day_date": Joi.string().example('2016-08-29T00:00:00.000Z'),
-    "day_usr_id": Joi.number().example(32).description('id of the user'),
     "day_target_time": DateTime,
+    "usr_id": Joi.number().example(32).description('id of the user'),
     "usr_firstname": Joi.string().example('jack').required(),
     "usr_lastname": Joi.string().example('Bauer').required(),
     "per_id": PeriodId,

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -102,5 +102,17 @@ const PostPeriod = Joi.object({
         .example('My awesome comment for the day')
         .description("a comment field for the user to add comments to a period"),
 }).label('Post Period');
-
 module.exports.PostPeriod = PostPeriod;
+
+const Vacancy = Joi.object({
+    "day_id": Joi.number().example('123'),
+    "day_date": Joi.string().example('2016-08-29T00:00:00.000Z'),
+    "day_usr_id": Joi.number().example(32).description('id of the user'),
+    "day_target_time": DateTime,
+    "usr_firstname": Joi.string().example('jack').required(),
+    "usr_lastname": Joi.string().example('Bauer').required(),
+    "per_id": PeriodId,
+    "per_comment":Joi.string().example('My awesome comment for the day').description('a comment field for the user to add comments to a period'),
+    "per_duration": DateTime,
+});
+module.exports.Vacancy = Vacancy;

--- a/src/config/manifest.js
+++ b/src/config/manifest.js
@@ -51,31 +51,31 @@ const manifest = {
                 register: './pg',
                 options: {
                     development :{
-                        "user": "postgres", 
-                        "password": "postgres", 
-                        "database": "ttrack", 
-                        "port": "5432", 
+                        "user": "postgres",
+                        "password": "postgres",
+                        "database": "ttrack",
+                        "port": "5432",
                         "host": "postgres",
-                        "driver": "pg", 
+                        "driver": "pg",
                         "schema": "public"
                     },
                     test:{
                         //connectionString: process.env.DATABASE_URL
-                        "user": "postgres", 
-                        "password": "postgres", 
-                        "database": "ttrack_test", 
-                        "port": "5432", 
+                        "user": "postgres",
+                        "password": "postgres",
+                        "database": "ttrack_test",
+                        "port": "5432",
                         "host": "postgres",
-                        "driver": "pg", 
+                        "driver": "pg",
                         "schema": "public"
                     },
                     production: {
-                        "user": "postgres", 
-                        "password": "postgres", 
-                        "database": "ttrack", 
-                        "port": "5432", 
+                        "user": "postgres",
+                        "password": "postgres",
+                        "database": "ttrack",
+                        "port": "5432",
                         "host": "localhost",
-                        "driver": "pg", 
+                        "driver": "pg",
                         "schema": "public"
                     }
                 }
@@ -83,8 +83,8 @@ const manifest = {
         },
         {
             plugin: './api',
-            options: { 
-                routes: { prefix: '/api' } 
+            options: {
+                routes: { prefix: '/api' }
             }
         },
         {
@@ -116,7 +116,7 @@ const manifest = {
                         }
                     },
                     documentationPath: '/docs',
-                }   
+                }
             }
         },{
             plugin: {


### PR DESCRIPTION
add a new api rest point for fetching all vacancies till today.

it will show the last 100 days by default, but one can easily paginate using query parameters start and limit.

the api endpoint returns the data in a meta information fashion:
```
{
    _meta: {
        total: 657,
        limit: 100,
        start: 600,
        count: 57
    },
    vacations: [
        ...
    ]
}
```

The `_meta` property will return the meta information like total count of found vacations, limit, start point, ... (you get the picture).