### PR TITLE
Add version output and api-versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "private": false,
   "ttrackServer": {
     "apiVersion": 1,
-    "compatibleApiVersions": [1]
+    "validVersions": [
+      1
+    ]
   },
   "dependencies": {
     "glue": "^4.1.0",
@@ -25,6 +27,7 @@
     "good-squeeze": "^5.0.2",
     "hapi": "^16.4.3",
     "hapi-405-routes": "^0.6.1",
+    "hapi-api-version": "^1.4.0",
     "inert": "^4.2.1",
     "joi-date-extensions": "^1.0.2",
     "knex": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttrack-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Another TimeTracking Tool",
   "author": "25th floor",
   "license": "MIT",
@@ -14,6 +14,10 @@
     "lint": "eslint . --ext .js"
   },
   "private": false,
+  "ttrackServer": {
+    "apiVersion": 1,
+    "compatibleApiVersions": [1]
+  },
   "dependencies": {
     "glue": "^4.1.0",
     "good": "^7.2.0",

--- a/src/api/handlers/home.js
+++ b/src/api/handlers/home.js
@@ -25,7 +25,7 @@ module.exports.list = {
                     schema: Joi.object({
                         "apiVersion": Joi.number().example(1),
                         "buildNumber": Joi.number().example(42),
-                        "compatibleApiVersions": Joi.array().items(Joi.number()).example([1,2]),
+                        "validVersions": Joi.array().items(Joi.number()).example([1,2]),
                         "git": Joi.string().example('964aa95'),
                         "version": Joi.string().example('1.2.3'),
                     }),
@@ -43,7 +43,7 @@ module.exports.list = {
         reply({
             ...buildInfo,
             apiVersion: packageJson.ttrackServer.apiVersion,
-            compatibleApiVersions: packageJson.ttrackServer.compatibleApiVersions,
+            validVersions: packageJson.ttrackServer.validVersions,
             version: packageJson.version,
         });
     },

--- a/src/api/handlers/home.js
+++ b/src/api/handlers/home.js
@@ -1,0 +1,50 @@
+const BaseJoi = require('joi');
+const Extension = require('joi-date-extensions');
+
+const packageJson = require('../../../package.json');
+
+const Joi = BaseJoi.extend(Extension);
+
+let buildInfo;
+try {
+    buildInfo = require('../../../buildinfo.json');
+} catch (e) {
+    buildInfo = {};
+}
+
+module.exports.list = {
+    id: 'Home',
+    tags: ['api'],
+    description: 'returns version of the api',
+    notes:'Returns all versioning information',
+    plugins: {
+        'hapi-swagger': {
+            responses: {
+                '200': {
+                    description: "Home",
+                    schema: Joi.object({
+                        "apiVersion": Joi.number().example(1),
+                        "buildNumber": Joi.number().example(42),
+                        "compatibleApiVersions": Joi.array().items(Joi.number()).example([1,2]),
+                        "git": Joi.string().example('964aa95'),
+                        "version": Joi.string().example('1.2.3'),
+                    }),
+                },
+                '400':{
+                    description: 'Bad Request',
+                },
+                '404':{
+                    description: 'Not Found',
+                }
+            },
+        },
+    },
+    handler: async function (request, reply) {
+        reply({
+            ...buildInfo,
+            apiVersion: packageJson.ttrackServer.apiVersion,
+            compatibleApiVersions: packageJson.ttrackServer.compatibleApiVersions,
+            version: packageJson.version,
+        });
+    },
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,7 +1,8 @@
-const User = require('./handlers/user');
+const Home = require('./handlers/home');
 const Period = require('./handlers/period');
 const PeriodTypes = require('./handlers/periodTypes');
 const Timesheet = require('./handlers/timesheet');
+const User = require('./handlers/user');
 const Vacations = require('./handlers/vacations');
 
 exports.register = (plugin, options, next) => {
@@ -24,6 +25,8 @@ exports.register = (plugin, options, next) => {
         // Vacations
         { method: 'GET' , path: '/vacations', config: Vacations.list },
 
+        // Home
+        { method: 'GET' , path: '/', config: Home.list },
     ]);
     next();
 };

--- a/src/config/manifest.js
+++ b/src/config/manifest.js
@@ -1,4 +1,4 @@
-
+const packageJson = require('../../package.json');
 
 const envKey = key => {
     const env = process.env.NODE_ENV || 'development';
@@ -37,12 +37,12 @@ const manifest = {
     ],
     registrations: [
         {
-            plugin:{
+            plugin: {
                 register: 'inert',
             }
         },
         {
-            plugin:{
+            plugin: {
                 register: 'vision',
             }
         },
@@ -50,33 +50,33 @@ const manifest = {
             plugin: {
                 register: './pg',
                 options: {
-                    development :{
-                        "user": "postgres",
-                        "password": "postgres",
-                        "database": "ttrack",
-                        "port": "5432",
-                        "host": "postgres",
-                        "driver": "pg",
-                        "schema": "public"
+                    development: {
+                        'user': 'postgres',
+                        'password': 'postgres',
+                        'database': 'ttrack',
+                        'port': '5432',
+                        'host': 'postgres',
+                        'driver': 'pg',
+                        'schema': 'public'
                     },
-                    test:{
+                    test: {
                         //connectionString: process.env.DATABASE_URL
-                        "user": "postgres",
-                        "password": "postgres",
-                        "database": "ttrack_test",
-                        "port": "5432",
-                        "host": "postgres",
-                        "driver": "pg",
-                        "schema": "public"
+                        'user': 'postgres',
+                        'password': 'postgres',
+                        'database': 'ttrack_test',
+                        'port': '5432',
+                        'host': 'postgres',
+                        'driver': 'pg',
+                        'schema': 'public'
                     },
                     production: {
-                        "user": "postgres",
-                        "password": "postgres",
-                        "database": "ttrack",
-                        "port": "5432",
-                        "host": "localhost",
-                        "driver": "pg",
-                        "schema": "public"
+                        'user': 'postgres',
+                        'password': 'postgres',
+                        'database': 'ttrack',
+                        'port': '5432',
+                        'host': 'localhost',
+                        'driver': 'pg',
+                        'schema': 'public'
                     }
                 }
             }
@@ -96,29 +96,30 @@ const manifest = {
             }
         },
         {
-            "plugin": {
-                'register': 'hapi-swagger',
-                'options': {
+            plugin: {
+                register: 'hapi-swagger',
+                options: {
                     tags: [{
-                        "name": "api",
-                        "description": "Public user calls"
+                        name: 'api',
+                        description: 'Public user calls'
                     }],
-                    "info": {
-                        "description": "This is the ttrack API",
-                        "version": "0.3.2",
-                        "title": "ttrack API",
-                        "contact": {
-                            "email": "ts@25th-floor.com",
+                    info: {
+                        description: 'This is the ttrack API',
+                        version: packageJson.version,
+                        title: 'ttrack API',
+                        contact: {
+                            email: 'ts@25th-floor.com',
                         },
-                        "license": {
-                            "name": "MIT",
-                            "url": "https://opensource.org/licenses/MIT"
+                        license: {
+                            name: 'MIT',
+                            url: 'https://opensource.org/licenses/MIT'
                         }
                     },
                     documentationPath: '/docs',
                 }
             }
-        },{
+        },
+        {
             plugin: {
                 register: 'good',
                 options: {
@@ -136,6 +137,16 @@ const manifest = {
                             args: [{ format: 'DD.MM.YYYY hh:mm:ss' }],
                         }, 'stdout']
                     }
+                }
+            }
+        },
+        {
+            plugin: {
+                register: 'hapi-api-version',
+                options: {
+                    validVersions: packageJson.ttrackServer.validVersions,
+                    defaultVersion: packageJson.ttrackServer.apiVersion,
+                    vendorName: 'ttrack'
                 }
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,15 @@ hapi-405-routes@^0.6.1:
     hoek "^4.0.2"
     joi "^9.0.4"
 
+hapi-api-version@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/hapi-api-version/-/hapi-api-version-1.4.0.tgz#19698488a5e98269f0aae75fd34a0376c1337109"
+  dependencies:
+    boom "^5.2.0"
+    hoek "^4.2.0"
+    joi "^10.6.0"
+    media-type "^0.3.0"
+
 hapi-capitalize-modules@1.x.x:
   version "1.1.6"
   resolved "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz#7991171415e15e6aa3231e64dda73c8146665318"
@@ -2938,7 +2947,7 @@ joi-date-extensions@^1.0.2:
     hoek "4.x.x"
     moment "2.x.x"
 
-joi@10.6.0, joi@10.x.x:
+joi@10.6.0, joi@10.x.x, joi@^10.6.0:
   version "10.6.0"
   resolved "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
   dependencies:
@@ -3362,6 +3371,10 @@ makeerror@1.0.x:
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
+media-type@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/media-type/-/media-type-0.3.1.tgz#5d569cdd0c52d9c41c7c6451973edd267fb21bcb"
 
 merge@^1.1.3:
   version "1.2.0"


### PR DESCRIPTION
This PR adds two features:
* it adds api-versioning using hapi-api-versions to define which api-version is compatible (useful for future refactorings)
* it adds a route to /api/ returning all the version information about the server (for the client to take)