### PR TITLE
allow users to define the target time for each day in the week

### DIFF
--- a/migrations/20171012131209-target-time-days.js
+++ b/migrations/20171012131209-target-time-days.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20171012131209-target-time-days-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20171012131209-target-time-days-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20171012131209-target-time-days-down.sql
+++ b/migrations/sqls/20171012131209-target-time-days-down.sql
@@ -103,3 +103,21 @@ BEGIN
   END;
 END
 $$;
+
+-- revert create_user
+CREATE OR REPLACE FUNCTION create_user (firstname TEXT, lastname TEXT, email TEXT, employment_start DATE, target INTERVAL)
+  RETURNS SETOF users
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY WITH inserted_user AS (
+    INSERT INTO users (usr_firstname, usr_lastname, usr_email, usr_employment_start)
+    VALUES (firstname, lastname, email, employment_start)
+    RETURNING *), inserted_target_time AS(
+    INSERT INTO user_target_times
+      SELECT usr_id, employment_start, 'infinity', target
+      FROM inserted_user
+    RETURNING *)
+  SELECT * FROM inserted_user;
+END
+$$;

--- a/migrations/sqls/20171012131209-target-time-days-down.sql
+++ b/migrations/sqls/20171012131209-target-time-days-down.sql
@@ -1,0 +1,105 @@
+-- remove new field
+ALTER TABLE user_target_times DROP COLUMN utt_target_time_days;
+
+-- revert function user_get_average_day_time
+CREATE OR REPLACE FUNCTION user_get_average_day_time (id INTEGER, day_date DATE) RETURNS INTERVAL
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        INTERVAL;
+BEGIN
+
+  SELECT utt_target_time/5
+  INTO   target
+  FROM   user_target_times
+  WHERE  utt_usr_id = id
+         AND    COALESCE(TSRANGE(utt_start, utt_end, '[)') @> day_date::TIMESTAMP, TRUE);
+
+
+  RETURN COALESCE(target, '00:00:00'::INTERVAL);
+END
+$$;
+
+
+-- revert function user_get_target_time
+CREATE OR REPLACE FUNCTION user_get_target_time (id INTEGER, day_date DATE) RETURNS interval
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        INTERVAL;
+  start_date    DATE;
+BEGIN
+
+  -- done explicitly to check if user exists, otherwise function doesn't get called due to the optimizer
+  SELECT user_get_start_date(id)
+  INTO   STRICT start_date;
+
+
+  SELECT CASE
+         WHEN day_date >= start_date  AND EXTRACT(ISODOW FROM day_date) < 6
+           THEN user_get_average_day_time(id, day_date)
+         ELSE '00:00:00'::INTERVAL
+         END
+  INTO   target;
+
+  RETURN target;
+END
+$$;
+
+-- revert function to get start date for user since it's used multiple times
+CREATE OR REPLACE FUNCTION user_add_new_target_time (id INTEGER, startdate DATE, target INTERVAL) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  old_target  INTERVAL;
+BEGIN
+  BEGIN
+    -- get old target time
+    SELECT utt_target_time
+    INTO STRICT old_target
+    FROM user_target_times
+    WHERE utt_usr_id = id
+          AND utt_end = 'infinity'
+          AND TSRANGE(utt_start, utt_end, '[)') @> startdate::TIMESTAMP;
+
+    -- first end the active one
+    UPDATE user_target_times
+    SET utt_end = startdate
+    WHERE utt_usr_id = id
+          AND utt_end = 'infinity'
+          AND TSRANGE(utt_start, utt_end, '[)') @> startdate::TIMESTAMP;
+
+    -- now create a new one
+    INSERT INTO user_target_times VALUES (id, startdate, 'infinity', target);
+
+    -- update days
+    -- update full days
+    UPDATE days SET day_target_time = target/5 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/5;
+    -- update half days
+    UPDATE days SET day_target_time = target/10 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/10;
+
+    -- update periods?
+    -- update full periods
+    UPDATE periods SET per_duration = target/5
+    FROM days
+    WHERE day_id = per_day_id
+          AND day_usr_id = id
+          AND day_date >= startdate
+          AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
+          AND per_duration = old_target/5;
+
+    -- update half day periods
+    UPDATE periods SET per_duration = target/10
+    FROM days
+    WHERE day_id = per_day_id
+          AND day_usr_id = id
+          AND day_date >= startdate
+          AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
+          AND per_duration = old_target/10;
+
+    EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE EXCEPTION 'user % not found', id;
+  END;
+END
+$$;

--- a/migrations/sqls/20171012131209-target-time-days-up.sql
+++ b/migrations/sqls/20171012131209-target-time-days-up.sql
@@ -117,3 +117,21 @@ BEGIN
   END;
 END
 $$;
+
+-- update create_user to use user_add_new_target_time
+CREATE OR REPLACE FUNCTION create_user (firstname TEXT, lastname TEXT, email TEXT, employment_start DATE, target INTERVAL)
+  RETURNS SETOF users
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY WITH inserted_user AS (
+    INSERT INTO users (usr_firstname, usr_lastname, usr_email, usr_employment_start)
+    VALUES (firstname, lastname, email, employment_start)
+    RETURNING *), inserted_target_time AS(
+    INSERT INTO user_target_times
+      SELECT usr_id, employment_start, 'infinity', target, ARRAY[target/5, target/5, target/5, target/5, target/5, '00:00:00'::INTERVAL, '00:00:00'::INTERVAL]
+      FROM inserted_user
+    RETURNING *)
+  SELECT * FROM inserted_user;
+END
+$$;

--- a/migrations/sqls/20171012131209-target-time-days-up.sql
+++ b/migrations/sqls/20171012131209-target-time-days-up.sql
@@ -1,0 +1,114 @@
+-- create new target times day field
+ALTER TABLE user_target_times ADD COLUMN utt_target_time_days INTERVAL[7];
+-- migrate present data into utt_target_time_days
+UPDATE user_target_times SET utt_target_time_days = ARRAY[
+  utt_target_time/5,
+  utt_target_time/5,
+  utt_target_time/5,
+  utt_target_time/5,
+  utt_target_time/5,
+  '00:00:00'::INTERVAL,
+  '00:00:00'::INTERVAL
+];
+
+-- update user_get_average_day_time
+CREATE OR REPLACE FUNCTION user_get_average_day_time (id INTEGER, day_date DATE) RETURNS INTERVAL
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        INTERVAL;
+BEGIN
+
+  SELECT utt_target_time_days[EXTRACT(ISODOW FROM day_date)]
+  INTO   target
+  FROM   user_target_times
+  WHERE  utt_usr_id = id
+         AND    COALESCE(TSRANGE(utt_start, utt_end, '[)') @> day_date::TIMESTAMP, TRUE);
+
+
+  RETURN COALESCE(target, '00:00:00'::INTERVAL);
+END
+$$;
+
+-- update user_get_target_time to not check for isodow
+CREATE OR REPLACE FUNCTION user_get_target_time (id INTEGER, day_date DATE) RETURNS interval
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        INTERVAL;
+  start_date    DATE;
+BEGIN
+
+  -- done explicitly to check if user exists, otherwise function doesn't get called due to the optimizer
+  SELECT user_get_start_date(id)
+  INTO   STRICT start_date;
+
+  SELECT CASE
+         WHEN day_date >= start_date
+           THEN user_get_average_day_time(id, day_date)
+         ELSE '00:00:00'::INTERVAL
+         END
+  INTO   target;
+
+  RETURN target;
+END
+$$;
+
+-- update user_add_new_target_time
+CREATE OR REPLACE FUNCTION user_add_new_target_time (id INTEGER, startdate DATE, target INTERVAL) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  old_target  INTERVAL;
+BEGIN
+  BEGIN
+    -- get old target time
+    SELECT utt_target_time
+    INTO STRICT old_target
+    FROM user_target_times
+    WHERE utt_usr_id = id
+          AND utt_end = 'infinity'
+          AND TSRANGE(utt_start, utt_end, '[)') @> startdate::TIMESTAMP;
+
+    -- first end the active one
+    UPDATE user_target_times
+    SET utt_end = startdate
+    WHERE utt_usr_id = id
+          AND utt_end = 'infinity'
+          AND TSRANGE(utt_start, utt_end, '[)') @> startdate::TIMESTAMP;
+
+    -- now create a new one
+    INSERT INTO user_target_times VALUES
+      (id, startdate, 'infinity', target, ARRAY[target/5, target/5, target/5, target/5, target/5, '00:00:00'::INTERVAL, '00:00:00'::INTERVAL]);
+
+    -- update days
+    -- update full days
+    UPDATE days SET day_target_time = target/5 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/5;
+    -- update half days
+    UPDATE days SET day_target_time = target/10 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/10;
+
+    -- update periods?
+    -- update full periods
+    UPDATE periods SET per_duration = target/5
+    FROM days
+    WHERE day_id = per_day_id
+          AND day_usr_id = id
+          AND day_date >= startdate
+          AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
+          AND per_duration = old_target/5;
+
+    -- update half day periods
+    UPDATE periods SET per_duration = target/10
+    FROM days
+    WHERE day_id = per_day_id
+          AND day_usr_id = id
+          AND day_date >= startdate
+          AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
+          AND per_duration = old_target/10;
+
+    EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE EXCEPTION 'user % not found', id;
+  END;
+END
+$$;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttrack-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Another TimeTracking Tool",
   "author": "25th floor",
   "license": "MIT",

--- a/src/api/__test__/api-period.test.js
+++ b/src/api/__test__/api-period.test.js
@@ -7,7 +7,7 @@ import { PERIOD_TYPE_IDS, createPeriodStubWithDayForUserAndDate } from '../../co
 
 const relativeTo = path.join(__dirname, '../../');
 
-const dummyUserSql = 'INSERT INTO users (usr_firstname , usr_lastname, usr_email, usr_employment_start) VALUES ( $1, $2, $3, $4) RETURNING *';
+const createUserSql = 'SELECT * FROM create_user( $1, $2, $3, $4, $5)';
 
 const apiCreatePath = (user) => `/api/users/${user}/periods/`;
 const apiPutAndDeletePath = (user,per_id) => `/api/users/${user}/periods/${per_id}`;
@@ -37,14 +37,14 @@ describe('ttrack API',() => {
 
         let user;
         beforeAll(async (done) => {
-            user = await query(dummyUserSql,['Mister', 'Smith', 'mister@smith.com','2001-01-01']);
+            user = await query(createUserSql,['Mister', 'Smith', 'mister@smith.com','2001-01-01', '38:30:00']);
             user = R.head(user.rows);
-            //TODO impl test target = await query(targetTimeSql,[user.usr_id, '2001-02-01', 'infinity', '38:30:00']);
             done();
         });
 
         afterAll(async (done) => {
             await query(`DELETE FROM days WHERE day_usr_id = ${user.usr_id}`);
+            await query(`DELETE FROM user_target_times WHERE utt_usr_id = ${user.usr_id}`);
             await query(`DELETE FROM users WHERE usr_id = ${user.usr_id}`);
             done();
         });
@@ -412,7 +412,7 @@ describe('ttrack API',() => {
                 let anotherPeriod;
 
                 beforeAll(async (done) => {
-                    const result = await query(dummyUserSql,['Mister', 'Anderson', 'mister@anderson.com','2001-01-01']);
+                    const result = await query(createUserSql,['Mister', 'Anderson', 'mister@anderson.com','2001-01-01', '38:30:00']);
                     anotherUser = R.head(result.rows);
                     anotherPeriod = await createPeriodStubWithDayForUserAndDate(anotherUser.usr_id, date);
                     done();
@@ -420,6 +420,7 @@ describe('ttrack API',() => {
 
                 afterAll(async (done) => {
                     await query(`DELETE FROM days WHERE day_usr_id = ${anotherUser.usr_id}`);
+                    await query(`DELETE FROM user_target_times WHERE utt_usr_id = ${anotherUser.usr_id}`);
                     await query(`DELETE FROM users WHERE usr_id = ${anotherUser.usr_id}`);
                     done();
                 });

--- a/src/api/__test__/api-timesheet.test.js
+++ b/src/api/__test__/api-timesheet.test.js
@@ -6,8 +6,7 @@ import manifest from '../../config/manifest';
 
 const relativeTo = path.join(__dirname, '../../');
 
-const dummyUserSql = 'INSERT INTO users (usr_firstname , usr_lastname, usr_email, usr_employment_start) VALUES ( $1, $2, $3, $4) RETURNING *';
-const targetTimeSql = 'INSERT INTO user_target_times (utt_usr_id , utt_start, utt_end, utt_target_time) VALUES ( $1, $2, $3, $4 ) RETURNING *';
+const createUserSql = 'SELECT * FROM create_user( $1, $2, $3, $4, $5)';
 
 const apiPath = (user, from, to) => `/api/users/${user}/timesheet/${from}/${to}`;
 
@@ -36,9 +35,8 @@ describe('ttrack API', () => {
         let user;
         // let target;
         beforeAll(async (done) => {
-            user = await query(dummyUserSql, ['Mister', 'Smith', 'mister@smith.com', '2001-01-01']);
+            user = await query(createUserSql, ['Mister', 'Smith', 'mister@smith.com', '2001-01-01', '38:30:00']);
             user = R.head(user.rows);
-            await query(targetTimeSql,[user.usr_id, '2001-01-01', 'infinity', '38:30:00']);
             done();
         });
 

--- a/src/api/__test__/timesheet.test.js
+++ b/src/api/__test__/timesheet.test.js
@@ -8,8 +8,7 @@ import moment from 'moment';
 
 const relativeTo = path.join(__dirname, '../../');
 
-const dummyUserSql = 'INSERT INTO users (usr_firstname , usr_lastname, usr_email, usr_employment_start) VALUES ( $1, $2, $3, $4) RETURNING *';
-const targetTimeSql = 'INSERT INTO user_target_times (utt_usr_id , utt_start, utt_end, utt_target_time) VALUES ( $1, $2, $3, $4 ) RETURNING *';
+const createUserSql = 'SELECT * FROM create_user( $1, $2, $3, $4, $5)';
 
 describe('Test TimeSheet functions', () => {
     let Server;
@@ -40,9 +39,8 @@ describe('Test TimeSheet functions', () => {
         };
 
         beforeAll(async (done) => {
-            user = await query(dummyUserSql, ['Mister', 'Smith', 'mister@smith.com', '2001-01-01']);
+            user = await query(createUserSql, ['Mister', 'Smith', 'mister@smith.com', '2001-01-01', '38:30:00']);
             user = R.head(user.rows);
-            await query(targetTimeSql,[user.usr_id, '2001-01-01', 'infinity', '38:30:00']);
             done();
         });
 


### PR DESCRIPTION
not just randomly week target time / 5

plz ignore the file  migrations/20171012131209-target-time-days.js - this is created by db-migrate.

the up migration updates the database table and functions with the new features, the down migration returns the the behaviour that is present at the moment.