### PR TITLE
move db-migrate to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     ]
   },
   "dependencies": {
+    "db-migrate": "^0.10.0-beta.20",
+    "db-migrate-pg": "^0.2.4",
     "glue": "^4.1.0",
     "good": "^7.2.0",
     "good-console": "^6.4.0",
@@ -49,8 +51,6 @@
     "blipp": "^2.3.0",
     "chakram": "^1.5.0",
     "code": "^4.1.0",
-    "db-migrate": "^0.10.0-beta.20",
-    "db-migrate-pg": "^0.2.4",
     "eslint": "^4.1.1",
     "eslint-plugin-import": "^2.6.1",
     "eslint-plugin-jest": "^20.0.3",


### PR DESCRIPTION
db-migrate is needed to execute database migrations